### PR TITLE
fix some typo in function compute_loss

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -213,8 +213,8 @@ class TrainerAnalyticalPointNetLK:
             voxel_coords_p1 = voxel_coords_p1.reshape(-1, voxel_coords_p1.shape[2]).to(device)
             gt_pose = gt_pose.reshape(-1, gt_pose.shape[2], gt_pose.shape[3]).to(device)
             
-            r = model.AnalyticalPointNetLK.do_forward(ptnetlk, voxel_features_p0_, voxel_coords_p0_,
-                    voxel_features_p1_, voxel_coords_p1_, self.max_iter, self.xtol, self.p0_zero_mean, self.p1_zero_mean, mode, data_type, num_random_points)
+            r = model.AnalyticalPointNetLK.do_forward(ptnetlk, voxel_features_p0, voxel_coords_p0,
+                    voxel_features_p1, voxel_coords_p1, self.max_iter, self.xtol, self.p0_zero_mean, self.p1_zero_mean, mode, data_type, num_random_points)
 
         estimated_pose = ptnetlk.g
 


### PR DESCRIPTION
voxel_features_p0_ in function `compute_loss` maybe typo with a extra underscore at the end. Now it's substituted with voxel_features_p0. Another three variables in function `comput_loss` have the same problem too.